### PR TITLE
Added port number and SSL configuration to the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Put the script in the `$GERRIT_HOME/hooks` directory and edit the script to set 
 
 If the name of the script is changed from patchset-created to something else don't forget to update the `[Hooks]` section of the `$GERRIT_HOME/etc/gerrit.config` to include `patchsetCreatedHook =  new_script_name`. For more information see the gerrit hooks [documentation][2].
 
+# Logging
+
+All print statements are appended to the `$GERRIT_HOME/logs/error_log`. 
+
 [0]:http://gerrit.googlecode.com
 [1]:http://redmine.org
 [2]:https://gerrit-review.googlesource.com/Documentation/config-hooks.html

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Introduction
+
 This is a simple [Gerrit][0] hook for updating [Redmine][1] with information about what changes
 are in Gerrit review.
 
@@ -10,7 +12,12 @@ under gerrit review.
 
 Script is tested with Redmine 2.4.1 and Gerrit 2.6.1
 
-Install it in $GERRIT_HOME/hooks and edit the script to set the variables at the beginning.
+# Installation
+
+Put the script in the `$GERRIT_HOME/hooks` directory and edit the script to set the variables at the beginning. If gerrit is installed on a Linux server don't forget to make the script executable. 
+
+If the name of the script is changed from patchset-created to something else don't forget to update the `[Hooks]` section of the `$GERRIT_HOME/etc/gerrit.config` to include `patchsetCreatedHook =  new_script_name`. For more information see the gerrit hooks [documentation][2].
 
 [0]:http://gerrit.googlecode.com
 [1]:http://redmine.org
+[2]:https://gerrit-review.googlesource.com/Documentation/config-hooks.html

--- a/patchset-created
+++ b/patchset-created
@@ -20,8 +20,15 @@
 # set your API key here. You can find it under "My account" in Redmine, i.e. http://redmine.mydomain.com/my/account
 REDMINE_API_KEY = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 
-# the hostname or ip number of redmine
+# the hostname or ip number of redmine, do not include the port number here.
 REDMINE_HOST = "redmine.mydomain.com"
+
+# The port number on which redmine is listening, change this to 443 if the
+# redmine host is using a secure connection 
+REDMINE_HOST_PORT_NUMBER = 80
+
+# Set this to true if the redmine host is using a secure connection (SSL)
+REDMINE_HOST_USING_SSL = False
 
 # if you want the script to update the status of the issue in redmine
 # you'll need to set this to the id number of that status. otherwise set
@@ -102,9 +109,10 @@ if __name__ == '__main__':
 
        puturl = "/issues/%d.json" % (redmineid)
 
-       connection = httplib.HTTPConnection(REDMINE_HOST, 80)
-# Use the following in case your host is using a secure connection
-#       connection = httplib.HTTPSConnection(REDMINE_HOST, 443)
+	   if REDMINE_HOST_USING_SSL:
+			connection = httplib.HTTPSConnection(REDMINE_HOST, REDMINE_HOST_PORT_NUMBER)
+	   else:
+			connection = httplib.HTTPConnection(REDMINE_HOST, REDMINE_HOST_PORT_NUMBER)
 
        connection.request('PUT', puturl, jsondata, {"Content-Type":"application/json", "X-Redmine-API-Key":REDMINE_API_KEY})
        response = connection.getresponse()

--- a/patchset-created
+++ b/patchset-created
@@ -109,10 +109,10 @@ if __name__ == '__main__':
 
        puturl = "/issues/%d.json" % (redmineid)
 
-	   if REDMINE_HOST_USING_SSL:
-			connection = httplib.HTTPSConnection(REDMINE_HOST, REDMINE_HOST_PORT_NUMBER)
-	   else:
-			connection = httplib.HTTPConnection(REDMINE_HOST, REDMINE_HOST_PORT_NUMBER)
+       if REDMINE_HOST_USING_SSL:
+           connection = httplib.HTTPSConnection(REDMINE_HOST, REDMINE_HOST_PORT_NUMBER)
+       else:
+           connection = httplib.HTTPConnection(REDMINE_HOST, REDMINE_HOST_PORT_NUMBER)
 
        connection.request('PUT', puturl, jsondata, {"Content-Type":"application/json", "X-Redmine-API-Key":REDMINE_API_KEY})
        response = connection.getresponse()


### PR DESCRIPTION
This should make the script easier to use, by moving all the SSL and port number configuration to the top of script. So that it should be easier to set up in the case of redmine instances not running behind a deafult port number. Also updated the readme to include some more installation information.
